### PR TITLE
Ramrod time is effected by flintlock skill

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/flintlock.dm
+++ b/code/game/objects/items/rogueweapons/ranged/flintlock.dm
@@ -44,13 +44,15 @@
 	rod = rrod
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/flintlock/attackby(obj/item/A, mob/user, params)
+	var/ramtime = 5.5
+	ramtime = ramtime - (user.mind.get_skill_level(/datum/skill/combat/flintlocks) / 2)
 	if(istype(A, /obj/item/ramrod))
 		if(!user.is_holding(src))
 			to_chat(user, "<span class='warning'>I need to hold \the [src] to ram it!</span>")
 			return
 		if(chambered)
 			if(!rammed)
-				if(do_after(user, 4 SECONDS, TRUE, src))
+				if(do_after(user, ramtime SECONDS, TRUE, src))
 					to_chat(user, "<span class='info'>I ram \the [src].</span>")
 					playsound(src.loc, 'sound/foley/nockarrow.ogg', 100, FALSE)
 					rammed = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

Default ramrodding time is 5.5 seconds, reduced by  0.5 seconds per level in flintlocks. This means standard musketeer infantry will ramrod in 4 seconds, which is the normal time it took before this PR. Lords will ramrod in 3.5 seconds. Sappers/Grenadiers in 5 seconds, and Zweihanders/Samurai in 5.5 seconds (though they cant shoot the gun anyway). 

If the other classes get merged, riflemen will ramrod in 3 seconds as they will have master level flintlocks.

Tested and works fine.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Makes flintlock skill and class differences slightly more meaningful.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
