### PR TITLE
fixes some pretty bad bugs, and adds more food to the maps

### DIFF
--- a/_maps/map_files/bloodfort/bloodfort.dmm
+++ b/_maps/map_files/bloodfort/bloodfort.dmm
@@ -78,6 +78,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors)
+"df" = (
+/obj/structure/fermenting_barrel/beer,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors)
 "dg" = (
 /obj/structure/stairs/stone/church{
 	dir = 1
@@ -284,6 +288,18 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors)
+"jG" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/turf/open/floor/rogue/tile/masonic/single,
+/area/rogue/indoors/town)
 "jW" = (
 /turf/open/floor/rogue/rooftop/green{
 	dir = 1
@@ -516,6 +532,18 @@
 	dir = 1
 	},
 /turf/open/transparent/openspace,
+/area/rogue/outdoors)
+"uL" = (
+/obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors)
 "uO" = (
 /obj/structure/throne,
@@ -1242,6 +1270,11 @@
 "XK" = (
 /obj/structure/warfarebarrier/red,
 /turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors)
+"Ya" = (
+/obj/structure/table/wood/plain,
+/obj/item/reagent_containers/food/snacks/rogue/prezzel,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors)
 "Yc" = (
 /obj/structure/ladder,
@@ -3893,7 +3926,7 @@ fC
 BJ
 fC
 fC
-fC
+df
 NA
 "}
 (35,1,1) = {"
@@ -3970,7 +4003,7 @@ uU
 fC
 fC
 fC
-uU
+Ya
 xm
 "}
 (36,1,1) = {"
@@ -4047,7 +4080,7 @@ fC
 fC
 fC
 fC
-fC
+uL
 xm
 "}
 (37,1,1) = {"
@@ -6831,7 +6864,7 @@ gA
 gA
 gA
 sY
-gA
+jG
 kj
 kj
 hH

--- a/_maps/map_files/laststand/laststand.dmm
+++ b/_maps/map_files/laststand/laststand.dmm
@@ -52,11 +52,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
 "bE" = (
-/obj/structure/table/wood/large/corner{
-	dir = 10
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town)
+/obj/structure/table/wood/plain,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors)
 "bH" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood,
@@ -107,6 +108,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors)
+"cI" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/peppersteak/plated,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town)
 "cM" = (
 /obj/machinery/light/rogue/lanternpost/fixed,
 /obj/structure/barricade/sandbags/rogue{
@@ -229,6 +238,13 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
+"fA" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "fH" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -259,6 +275,14 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town)
+"gI" = (
+/obj/structure/table/church{
+	dir = 1;
+	icon_state = "churchtable"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/breadslice,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town)
 "gN" = (
 /turf/open/floor/rogue/blocks,
@@ -371,12 +395,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"jc" = (
+/obj/structure/table/wood/large/corner{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/snacks/rogue/raisinbreadslice,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town)
 "jf" = (
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors)
-"js" = (
-/obj/structure/table/wood/plain,
-/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors)
 "jI" = (
 /turf/open/floor/rogue/grass,
@@ -611,10 +638,25 @@
 /obj/effect/landmark/start/grenzellord,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"oK" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "oN" = (
 /obj/structure/well/fountain,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors)
+"oQ" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/preserved/onion_fried,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "pc" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -682,12 +724,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors)
-"qF" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town)
 "qJ" = (
 /obj/structure/chair/stool/rogue{
 	pixel_y = 5
@@ -828,6 +864,14 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"ua" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/cheddar/aged,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "uf" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1;
@@ -865,6 +909,14 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town)
+"vn" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable_mid"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/raisinbread,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town)
 "vo" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -875,6 +927,22 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors)
+"vC" = (
+/obj/structure/closet/crate/chest{
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt";
+	name = "meat chest"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town)
 "vJ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
@@ -940,6 +1008,14 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors)
+"ww" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
+/obj/item/reagent_containers/food/snacks/rogue/meat/salami/slice,
+/turf/open/floor/rogue/ruinedwood,
+/area/rogue/indoors/town)
 "wD" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -1085,6 +1161,11 @@
 "ze" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town)
+"zs" = (
+/obj/structure/table/wood/plain,
+/obj/item/reagent_containers/food/snacks/rogue/raisinbreadslice,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors)
 "zJ" = (
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town)
@@ -1097,13 +1178,6 @@
 	icon_state = "stonestairs"
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town)
-"zT" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "zV" = (
 /obj/structure/chair/wood/rogue{
@@ -1253,6 +1327,22 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"EA" = (
+/obj/structure/closet/crate/chest{
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt";
+	name = "meat chest"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors)
 "ED" = (
 /obj/structure/table/wood/large/corner{
 	dir = 6
@@ -1440,6 +1530,23 @@
 /obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors)
+"Ih" = (
+/obj/structure/table/wood/large/corner{
+	dir = 10
+	},
+/obj/item/reagent_containers/food/snacks/rogue/raisinbreadslice,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town)
+"Ii" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/bread,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town)
 "Im" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
@@ -1515,6 +1622,13 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
+/area/rogue/indoors/town)
+"KT" = (
+/obj/structure/table/wood/large/corner{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town)
 "KV" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -1660,6 +1774,11 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"NI" = (
+/obj/structure/table/wood/plain,
+/obj/item/reagent_containers/food/snacks/rogue/prezzel,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors)
 "NM" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/blocks,
@@ -1898,18 +2017,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
-"SZ" = (
-/obj/structure/closet/crate/chest{
-	base_icon_state = "woodchestalt";
-	icon_state = "woodchestalt";
-	name = "meat chest"
-	},
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/turf/open/floor/rogue/ruinedwood,
-/area/rogue/indoors/town)
 "Tq" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -2063,13 +2170,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors)
-"XM" = (
-/obj/structure/table/church{
-	dir = 1;
-	icon_state = "churchtable"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town)
 "XS" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -2249,7 +2349,7 @@ Dr
 yw
 Wa
 rB
-Wa
+oK
 ZF
 jI
 jI
@@ -2330,13 +2430,13 @@ KN
 jI
 KN
 ZF
-SZ
+vC
 Dr
 Dr
-qF
+ww
 In
 Wa
-Wa
+oQ
 ZF
 KN
 jI
@@ -2423,7 +2523,7 @@ Dr
 ts
 In
 Wa
-Wa
+fA
 ZF
 KN
 jI
@@ -2507,7 +2607,7 @@ ZF
 bR
 Dr
 Dr
-zT
+cI
 In
 Wa
 MI
@@ -2594,10 +2694,10 @@ ZF
 sy
 Dr
 Dr
-zT
+ts
 In
 Wa
-Wa
+oK
 ZF
 KN
 KN
@@ -2684,7 +2784,7 @@ Dr
 HQ
 In
 Wa
-Wa
+ua
 ZF
 Zi
 yo
@@ -2768,10 +2868,10 @@ ZF
 Tv
 Dr
 Dr
-zT
+vn
 In
 Wa
-Wa
+fA
 ZF
 Gt
 jf
@@ -3550,7 +3650,7 @@ jI
 lN
 jI
 ZF
-wg
+Ii
 tx
 DU
 mb
@@ -5320,7 +5420,7 @@ kG
 jI
 ke
 on
-js
+NI
 qJ
 KN
 lN
@@ -5493,7 +5593,7 @@ KN
 kG
 jI
 ke
-js
+zs
 XK
 qJ
 KN
@@ -5620,7 +5720,7 @@ Yn
 JE
 JE
 JE
-XM
+gI
 zJ
 nl
 ZF
@@ -5758,7 +5858,7 @@ TM
 TM
 KN
 KN
-KN
+bE
 KN
 qY
 mA
@@ -5845,7 +5945,7 @@ nv
 KN
 hR
 KN
-lN
+EA
 KN
 ad
 KN
@@ -6823,7 +6923,7 @@ BB
 pc
 xQ
 Ly
-bE
+Ih
 ru
 pc
 BB
@@ -6996,7 +7096,7 @@ qp
 TC
 pc
 xQ
-Sn
+KT
 lT
 ru
 pc
@@ -7170,7 +7270,7 @@ qp
 BB
 pc
 xQ
-Sn
+jc
 UF
 ru
 pc

--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -15,10 +15,12 @@
 	var/lit = FALSE
 	var/prob2fail = 23
 
+/*
 /obj/item/bomb/dropped(mob/user, silent)
 	. = ..()
 	if(lit)
-		explode()
+		explode() 
+*/
 
 /obj/item/bomb/fire
 	name = "fire bomb"

--- a/code/modules/jobs/job_types/roguetown/warfare.dm
+++ b/code/modules/jobs/job_types/roguetown/warfare.dm
@@ -482,11 +482,11 @@ datum/advclass/blu/grenadier ///Less gun related skills in exchange for some bom
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	belt = /obj/item/storage/belt/rogue/leather
-	beltr = /obj/item/gun/revolver/grenadelauncher/flintlock/pistol
+	beltr = /obj/item/gun/ballistic/revolver/grenadelauncher/flintlock/pistol
 	beltl = /obj/item/rogueweapon/woodcut/steel
-	beltr = /obj/item/quiver/bullets
+	backr = /obj/item/quiver/bullets
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	head = /obj/item/clothing/head/roguetown/helmet/kettl
+	head = /obj/item/clothing/head/roguetown/helmet/kettle
 	backl = /obj/item/storage/backpack/rogue/backpack
 	backpack_contents = list(/obj/item/bomb = 3, /obj/item/flint = 1)
 	if(H.mind)
@@ -522,7 +522,7 @@ datum/advclass/blu/blujester ///Mostly a joke class. They do move fast though an
 	pants = /obj/item/clothing/under/roguetown/tights
 	armor = /obj/item/clothing/suit/roguetown/shirt/jester
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = pick(/obj/item/rogueweapon/huntingknife/cleaver/combat, /obj/item/rogueweapon/sword/rapier, /obj/item/bomb, /obj/item/restraints/legcuffs/beartrap)
+	beltl = pick(/obj/item/rogueweapon/huntingknife/cleaver/combat, /obj/item/rogueweapon/sword/rapier, /obj/item/bomb)
 	backr = /obj/item/rogue/instrument/accord
 	head = /obj/item/clothing/head/roguetown/jester
 	playsound(H, 'sound/foley/honk.ogg', 100, FALSE, 2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

Fixed jester sometimes spawning with nothing on their belt (mantrap cant go on the belt so if it gets picked, they just get nothing)

Fixed Grenadier's helmet (missed an 'e' in 'kettle')

fixed Grenadier's pistol not having the right path

fixed duplicate belt item slots in Grenadier (they had a pistol and bullet pouch in the same place, moved the pouch to their back so the pistol can fit)

Commented out grenades exploding when dropped because it also caused them to instantly explode when thrown (blowing up the person even though they were using it correctly)


also gives both sides on both maps a fair amount more of food so there should be plenty to go around, hopefully.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

These are some pretty important bugs to fix.

Also both sides need more food!


ps: this works locally, i cant help it if it doesn't work on the server or not, pal

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
