### PR TITLE
Speed Granulation, officers, and Inspiration

### DIFF
--- a/code/datums/skills/misc.dm
+++ b/code/datums/skills/misc.dm
@@ -37,3 +37,6 @@
 
 /datum/skill/misc/weaving
 	name = "Weaving"
+
+/datum/skill/misc/leadership
+	name = "Leadership"

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -223,3 +223,25 @@
 	name = "Divine Knowledge"
 	desc = "<span class='nicegreen'>Divine knowledge flows through me.</span>\n"
 	icon_state = "intelligence"
+
+/datum/status_effect/buff/inspired
+	id = "inspired"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/inspired
+	effectedstats = list("speed" = 1,"constitution" = 1,"endurance" = 1)
+	duration = 2 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/inspired
+	name = "Inspired"
+	desc = "<span class='nicegreen'>I'm inspired to fight!</span>\n"
+	icon_state = "intelligence"
+
+/datum/status_effect/buff/inspired/great
+	id = "inspired_great"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/inspired/great
+	effectedstats = list("speed" = 1,"constitution" = 1,"endurance" = 1,"strength" = 1)
+	duration = 3 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/inspired/great
+	name = "Greatly Inspired"
+	desc = "<span class='nicegreen'>I feel very inspired to fight!</span>\n"
+	icon_state = "intelligence"

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -408,6 +408,16 @@
 /obj/item/clothing/suit/roguetown/armor/leather/vest/black
 	color = "#3c3a38"
 
+/obj/item/clothing/suit/roguetown/armor/leather/vest/warfare/equipped(mob/user, slot)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_GENERIC)
+
+/obj/item/clothing/suit/roguetown/armor/leather/vest/warfare/red
+	color = "#a32121"
+
+/obj/item/clothing/suit/roguetown/armor/leather/vest/warfare/blue
+	color = "#8747b1"
+
 /obj/item/clothing/suit/roguetown/armor/workervest
 	name = "striped tunic"
 	desc = "A common tunic worn by just about anyone. Nothing special, but essential."

--- a/code/modules/jobs/job_types/roguetown/warfare.dm
+++ b/code/modules/jobs/job_types/roguetown/warfare.dm
@@ -62,11 +62,13 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/flintlocks, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/leadership, 5, TRUE)
 		H.change_stat("strength", 1)
 		H.change_stat("intelligence", 3)
 		H.change_stat("endurance", 3)
 		H.change_stat("speed", 1)
 		H.change_stat("perception", 2)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/inspire)
 
 ////////////// RED SOLDIERS AND CLASSES /////////////////
 
@@ -280,7 +282,7 @@
 	beltl = /obj/item/rogueweapon/huntingknife/cleaver/combat
 	beltr = /obj/item/quiver/bullets
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	head = /obj/item/clothing/head/roguetown/fancyhat
+	head = /obj/item/clothing/head/roguetown/bardhat
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/flintlock
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
@@ -297,6 +299,40 @@
 		H.change_stat("endurance", -4)
 		H.change_stat("speed", -1)
 		H.change_stat("constitution", -3)
+
+//// OFFICER ////
+
+/datum/advclass/red/officer
+	name = "Officer"
+	tutorial = "Officers who have been given good training in tactics, strategy, and inspiring the men, but are not as good at fighting as the common soldiery."
+	outfit = /datum/outfit/job/roguetown/redofficer
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = ALL_RACES_LIST_NAMES
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	category_tags = list(CTAG_REDSOLDIER)
+	maximum_possible_slots = 99
+
+/datum/outfit/job/roguetown/redofficer/pre_equip(mob/living/carbon/human/H, visualsOnly)
+	..()
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/warfare/red
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	belt = /obj/item/storage/belt/rogue/leather
+	beltl = /obj/item/rogueweapon/sword/rapier
+	beltr = /obj/item/gun/ballistic/revolver/grenadelauncher/flintlock/pistol
+	head = /obj/item/clothing/head/roguetown/fancyhat
+	backr = /obj/item/quiver/bullets
+	gloves = /obj/item/clothing/gloves/roguetown/leather/black
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/flintlocks, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/leadership, 3, TRUE)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/inspire)
+		H.change_stat("intelligence", 3)
 
 
 
@@ -351,11 +387,13 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/flintlocks, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/leadership, 5, TRUE)
 		H.change_stat("strength", 1)
 		H.change_stat("intelligence", 3)
 		H.change_stat("endurance", 3)
 		H.change_stat("speed", 1)
 		H.change_stat("perception", 2)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/inspire)
 
 
 
@@ -562,7 +600,7 @@ datum/advclass/blu/blujester ///Mostly a joke class. They do move fast though an
 	beltl = /obj/item/rogueweapon/huntingknife/cleaver/combat
 	beltr = /obj/item/quiver/bullets
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	head = /obj/item/clothing/head/roguetown/fancyhat
+	head = /obj/item/clothing/head/roguetown/bardhat
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/flintlock
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
@@ -580,3 +618,37 @@ datum/advclass/blu/blujester ///Mostly a joke class. They do move fast though an
 		H.change_stat("endurance", -4)
 		H.change_stat("speed", -1)
 		H.change_stat("constitution", -3)
+
+//// OFFICER ////
+
+/datum/advclass/blu/officer
+	name = "Officer"
+	tutorial = "Officers who have been given good training in tactics, strategy, and inspiring the men, but are not as good at fighting as the common soldiery."
+	outfit = /datum/outfit/job/roguetown/bluofficer
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = ALL_RACES_LIST_NAMES
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
+	category_tags = list(CTAG_BLUSOLDIER)
+	maximum_possible_slots = 99
+
+/datum/outfit/job/roguetown/bluofficer/pre_equip(mob/living/carbon/human/H, visualsOnly)
+	..()
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/warfare/blue
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	belt = /obj/item/storage/belt/rogue/leather
+	beltl = /obj/item/rogueweapon/sword/rapier
+	beltr = /obj/item/gun/ballistic/revolver/grenadelauncher/flintlock/pistol
+	head = /obj/item/clothing/head/roguetown/fancyhat
+	backr = /obj/item/quiver/bullets
+	gloves = /obj/item/clothing/gloves/roguetown/leather/black
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/flintlocks, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/leadership, 3, TRUE)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/inspire)
+		H.change_stat("intelligence", 3)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -58,10 +58,10 @@
 			mod = CONFIG_GET(number/movedelay/run_delay)
 		if(MOVE_INTENT_SNEAK)
 			mod = 6
-	if(STASPD < 6)
-		mod = mod+1
-	if(STASPD > 14)
-		mod = mod-0.5
+	var/spdchange = (10-STASPD)*0.1
+	spdchange = clamp(spdchange, -0.5, 1)  //if this is not clamped, jesters can run faster than they should.
+	mod = mod+spdchange
+	//maximum speed is achieved at 15 speed.
 	add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, override = TRUE, multiplicative_slowdown = mod)
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)

--- a/code/modules/spells/roguetown/warfare.dm
+++ b/code/modules/spells/roguetown/warfare.dm
@@ -1,0 +1,32 @@
+/obj/effect/proc_holder/spell/targeted/inspire
+    name = "Inspire"
+    overlay_state = "bcry"
+    releasedrain = 30
+    chargedrain = 0
+    chargetime = 0
+    range = 7
+    warnie = "sydwarning"
+    sound = 'sound/magic/inspire_02.ogg'
+    invocation = "Fight with all you got!"
+    invocation_type = "shout"
+    associated_skill = /datum/skill/misc/leadership
+    antimagic_allowed = TRUE
+    charge_max = 25 SECONDS
+    max_targets = 0
+    cast_without_targets = TRUE
+
+/obj/effect/proc_holder/spell/targeted/inspire/cast(list/targets, mob/living/user)
+    for(var/mob/living/carbon/human/H in targets)
+        var/isenemy = FALSE
+        if(ishuman(user))
+            var/mob/living/carbon/human/U = user
+            if(U.warfare_faction != H.warfare_faction)
+                isenemy = TRUE
+            if(!isenemy)
+                if( 4 < user.mind.get_skill_level(/datum/skill/misc/leadership))
+                    H.apply_status_effect(/datum/status_effect/buff/inspired/great) //yes, you can stack inspirations from different levels of leadership
+                else
+                    H.apply_status_effect(/datum/status_effect/buff/inspired)
+                H.visible_message("<span class='info'>[H] looks more eager to fight!</span>", "<span class='notice'>I feel inspired to fight!</span>")
+    ..()
+    return TRUE

--- a/stonekeep.dme
+++ b/stonekeep.dme
@@ -3234,6 +3234,7 @@
 #include "code\modules\spells\roguetown\monk.dm"
 #include "code\modules\spells\roguetown\priest.dm"
 #include "code\modules\spells\roguetown\spider.dm"
+#include "code\modules\spells\roguetown\warfare.dm"
 #include "code\modules\spells\roguetown\wizard.dm"
 #include "code\modules\spells\roguetown\acolyte\astrata.dm"
 #include "code\modules\spells\roguetown\acolyte\dendor.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

First, speed granulation from stonekeep/ratkeep is ported over. Speed change is now gradual instead of you becoming super slow at 5 speed and super fast at 15 speed. This means at 13 speed, you still move faster, while at 8 speed you move slower than average. Max and lowest speeds are unchanged. This is technically a Ninja buff as their +2 speed will matter more now, while riflemen will be slightly slower and Samurai/Grenadiers will not be able to completely ignore their speed debuffs by going female elf.

Second, minor thing, riflemen get bard hats instead of fancy hats. No functional difference but fashion wise.

Next, adds 'Inspiration' as a mechanic and spell. When used, all team mates nearby will be inspired based on your 'leadership' skill. If you have a high leadership skill they will be greatly inspired, while if it is lower they will receive a normal inspiration. Normal inspiration buffs speed, constitution, and endurance by +1 for 2 minutes, while great inspiration buffs speed, constitution, endurance, and strength by +1 for 3 minutes. Both inspirations will be able to stack on top of each other, but you can't stack multiple normal or great inspirations.

Lastly, adds a new class: 'Officer'. The officer is available to both sides. They do not get extra physical stats or perception like musketeers, and they have almost no armor. They also have slightly worse matchlock skills, and utilize a rapier and pistol to fight. In exchange, they have moderate leadership skill and the 'Inspire' ability, so they can give normal inspiration to team mates.

![image](https://github.com/user-attachments/assets/7098f1d8-edb2-4196-b5e0-92f40b5c90a7)
(A Grenzelhoft officer. Heartfelt ones are identical except for having a red vest instead of a purple one.)

As a note, both lords have Master Leadership skill, have the 'Inspire' ability, and are the only ones who can give 'Great Inspiration'.


thoroughly tested, and spent a good bit of effort making sure nothing runtimes.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Makes the lords on both sides a bit more useful since they can give bonuses to their team mates.

Adds a support class, that while I suspect their support is going to be underpowered, it is still nice. Plus, more class variety is cool.

Speed granulation will be very good, as it will give more class balancing abilities and is in fact a big part of why inspire will be useful since it will let you speed up your team mates slightly for a charge.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
