### PR TITLE
horsing around... plus a few other changes

### DIFF
--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -51,6 +51,11 @@
 	new /obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison(src)
 	new /obj/item/reagent_containers/food/snacks/grown/berries/rogue/poison(src)
 
+/obj/item/storage/belt/rogue/leather/bullet/PopulateContents()
+	new /obj/item/ammo_casing/caseless/rogue/bullet(src)
+	new /obj/item/ammo_casing/caseless/rogue/bullet(src)
+	new /obj/item/ammo_casing/caseless/rogue/bullet(src)
+
 /obj/item/storage/belt/rogue/leather/plaquegold
 	name = "plaque belt"
 	icon_state = "goldplaque"

--- a/code/modules/jobs/job_types/roguetown/warfare.dm
+++ b/code/modules/jobs/job_types/roguetown/warfare.dm
@@ -138,6 +138,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 		H.change_stat("strength", 1)
 		H.change_stat("perception", 1)
 		H.change_stat("endurance", 1)
@@ -184,6 +185,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 		H.change_stat("strength", 1)
 		H.change_stat("perception", -1)
 		H.change_stat("endurance", 1)
@@ -249,13 +251,13 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/warfare/black
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/merc
 	shoes = /obj/item/clothing/shoes/roguetown/boots
-	belt = /obj/item/storage/belt/rogue/leather
+	belt = /obj/item/storage/belt/rogue/leather/bullet
 	beltl = /obj/item/rogueweapon/huntingknife/cleaver/combat
 	beltr = /obj/item/gun/ballistic/revolver/grenadelauncher/flintlock/pistol
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/ammo_casing/caseless/rogue/bullet = 3)
+	backpack_contents = list(/obj/item/bomb/smoke = 1, /obj/item/flint = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/flintlocks, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE) //average bow skills, for silent killings
@@ -343,6 +345,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/leadership, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/inspire)
 		H.change_stat("intelligence", 3)
 
@@ -474,6 +477,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 		H.change_stat("strength", 1)
 		H.change_stat("perception", 1)
 		H.change_stat("endurance", 1)
@@ -509,6 +513,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 		H.change_stat("strength", 2)
 		H.change_stat("perception", -1)
 		H.change_stat("endurance", 2)
@@ -665,5 +670,6 @@ datum/advclass/blu/blujester ///Mostly a joke class. They do move fast though an
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/leadership, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/inspire)
 		H.change_stat("intelligence", 3)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -812,7 +812,12 @@ mob/living/simple_animal/handle_fire()
 		if(riding_datum.handle_ride(user, direction))
 			riding_datum.vehicle_move_delay = move_to_delay
 			if(user.m_intent == MOVE_INTENT_RUN)
-				riding_datum.vehicle_move_delay -= 1
+				if(user.mind)
+					var/amt = user.mind.get_skill_level(/datum/skill/misc/riding)
+					if(amt > 3) //for the future, if we give anyone expert skilled riding
+						riding_datum.vehicle_move_delay -= 0.5
+					else
+						riding_datum.vehicle_move_delay -= 1
 				if(loc != oldloc)
 					var/turf/open/T = loc
 					if(!do_footstep && T.footstep)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -812,7 +812,7 @@ mob/living/simple_animal/handle_fire()
 		if(riding_datum.handle_ride(user, direction))
 			riding_datum.vehicle_move_delay = move_to_delay
 			if(user.m_intent == MOVE_INTENT_RUN)
-				riding_datum.vehicle_move_delay -= 0.5 //considering you cant run into walls, running shouldnt give that much of a bonus
+				riding_datum.vehicle_move_delay -= 1
 				if(loc != oldloc)
 					var/turf/open/T = loc
 					if(!do_footstep && T.footstep)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -812,7 +812,7 @@ mob/living/simple_animal/handle_fire()
 		if(riding_datum.handle_ride(user, direction))
 			riding_datum.vehicle_move_delay = move_to_delay
 			if(user.m_intent == MOVE_INTENT_RUN)
-				riding_datum.vehicle_move_delay -= 1
+				riding_datum.vehicle_move_delay -= 0.5 //considering you cant run into walls, running shouldnt give that much of a bonus
 				if(loc != oldloc)
 					var/turf/open/T = loc
 					if(!do_footstep && T.footstep)
@@ -831,21 +831,27 @@ mob/living/simple_animal/handle_fire()
 			if(user.mind)
 				var/amt = user.mind.get_skill_level(/datum/skill/misc/riding)
 				if(amt)
-					riding_datum.vehicle_move_delay -= 7
-				else
-					riding_datum.vehicle_move_delay -= 4
+					riding_datum.vehicle_move_delay -= amt/2
+				riding_datum.vehicle_move_delay -= 4
 			if(loc != oldloc)
 				var/obj/structure/mineral_door/MD = locate() in loc
-				if(MD && !MD.ridethrough)
+				var/obj/structure/stairs/ST = locate() in loc
+				if(MD && !MD.ridethrough || ST)
 					if(isliving(user))
 						var/mob/living/L = user
 						var/strong_thighs = L.mind.get_skill_level((/datum/skill/misc/riding))
 						if(prob(60 - (strong_thighs * 10))) // Legendary riders do not fall!
-							unbuckle_mob(L)
-							L.Paralyze(50)
-							L.Stun(50)
-							playsound(L.loc, 'sound/foley/zfall.ogg', 100, FALSE)
-							L.visible_message("<span class='danger'>[L] falls off [src]!</span>")
+							if(MD)
+								unbuckle_mob(L)
+								L.Paralyze(50)
+								L.Stun(50)
+								playsound(L.loc, 'sound/foley/zfall.ogg', 100, FALSE)
+								L.visible_message("<span class='danger'>[L] falls off [src]!</span>")
+							else //stumbling on stairs is less punishing than hitting the top of a door
+								unbuckle_mob(L)
+								L.Stun(30)
+								L.visible_message("<span class='danger'>[L] is shaken off [src] as it stumbles from the stairs!</span>")
+
 
 /mob/living/simple_animal/buckle_mob(mob/living/buckled_mob, force = 0, check_loc = 1)
 	. = ..()

--- a/modular/Barding/code/Barding_instruments.dm
+++ b/modular/Barding/code/Barding_instruments.dm
@@ -243,7 +243,7 @@
 		if(attuned == "UNIVERSAL")
 			for(var/mob/M in GLOB.player_list)
 				if(M.can_hear())
-					to_chat(M, "<br><span class='alert'>[message]</span>")
+					to_chat(M, "<br><span class='alert'>Incoming universal message: [message]</span>")
 					M.playsound_local(M.loc, 'sound/foley/trumpt.ogg', 75)
 		else
 			if(istype(SSticker.mode, /datum/game_mode/warfare))
@@ -259,5 +259,5 @@
 						team = C.heartfelts
 				for(var/mob/M in team)
 					if(M.can_hear())
-						to_chat(M, "<br><span class='alert'>[message]</span>")
+						to_chat(M, "<br><span class='alert'>Incoming team message: [message]</span>")
 						M.playsound_local(M.loc, 'sound/foley/trumpt.ogg', 75)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

ninja's bullets moved to their belt, and they get one smoke bomb and a flint in their satchel. 

Signal trumpets will tell you if a message is universal or for a team. Otherwise their usefulness is much diminished if the enemy can very easily forge announcements. 

Balances riding speeds (they were overtuned a little bit...). Riding speed scales with riding skill instead of just being binary, fast if you have any riding skill at all and slow if you don't.

horse running speed is normal if you have skilled riding or lower. At expert riding level, horse running speed bonus is lowered but you still get faster standard movement. This means someone one a horse with expert riding running will move at the same speed as someone with skilled riding, however without running, the expert will move quicker. This is because any higher speed amounts is actually insane.

-----
**As a note for self or John... do not give people master or legendary riding skill. They will move so fucking fast on horses.**
Nothing breaks of course, but it looks silly, the sounds are silly, and it is unbalanced.
I was thinking of putting a cap, but i'll leave it this way incase you do want to do the silly stuff.
-----

Saigas can stumble on stairs, to balance out horse riders. Stumbling makes the rider fall off and be stunned for 3 seconds, but unlike hitting a door they don't fall to the ground, and are stunned for a shorter duration.  This will makes horse riders less useful indoors, but still the same in outdoors settings (as it should be)

Officers get skilled riding, since it kinda makes sense and gives them another use aside from their pretty mid support ability. 

Musketeers on both sides, and zweihanders/samurai get average riding, so riding is somewhat useful to them and you can kind of emulate being a lancer/dragoon.

All other classes still have no riding skill, so riding a horse is kind of worse than not riding it, pretty much how it was before.

i was going to add dedicated lancer/dragoon classes but honestly i feel like it's better to not have them, and just let existing classes be able to do their role if they can get their hands on a horse.

as always, this was tested...

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

while funny, when i tested the recently changed horse speeds i was zooming around like a bullet, and I figured it would be nigh impossible to stop without a lucky musket shot. This will make the speeds much more reasonable, while still letting horse riders generally be speedier than on foot counterparts so long as their class has some riding skill.

Giving Ninjas a smoke bomb should make them competitive enough that no more buffs should be needed. Probably.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
