### PR TITLE
WE'RE SO FARKING BACK

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -53,7 +53,7 @@
 #define TRAIT_STEELHEARTED "steelhearted" //no bad mood from dismembering or seeing this
 #define TRAIT_IWASREVIVED "iwasrevived" //prevents PQ gain from reviving the same person twice
 #define TRAIT_IWASUNZOMBIFIED "iwasunzombified" //prevents PQ gain from curing a zombie twice
-#define TRAIT_BIGHANDS "Heavy Handed"
+#define TRAIT_UNTRAINED "Untrained"
 
 GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_WEBWALK = "I can move freely between webs.",
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_CYCLOPS_RIGHT = "<span class='warning'>My right eye has been poked out...</span>",
 	TRAIT_LEECHIMMUNE = "Leeches are reluctant to bite me.",
 	TRAIT_RETARD_ANATOMY = "My anatomy is inhumen, preventing me from wearing hats and shoes.",
-	TRAIT_BIGHANDS = "I am unable to use certain weapons, such as Barkweapons."
+	TRAIT_UNTRAINED = "I am unable to use certain weapons, such as Barkweapons."
 	))
 
 // trait accessor defines

--- a/code/game/objects/items/rogueweapons/ranged/flintlock.dm
+++ b/code/game/objects/items/rogueweapons/ranged/flintlock.dm
@@ -302,8 +302,10 @@
 			to_chat(user, "<span class='info'>I dry fire \the [src]!</span>")
 			cocked = FALSE
 			return
-		if(HAS_TRAIT(user, TRAIT_BIGHANDS))
-			to_chat(user, "<span class='info'>I can't use this!</span>")
+		if(HAS_TRAIT(user, TRAIT_UNTRAINED))
+			to_chat(user, "<span class='info'>I don't know how this works.</span>")
+			playsound(src.loc, 'sound/items/match_fail.ogg', 100, FALSE)
+			cocked = FALSE
 			return
 		if(user.client.chargedprog >= 100)
 			spread = 0

--- a/code/modules/jobs/job_types/roguetown/warfare.dm
+++ b/code/modules/jobs/job_types/roguetown/warfare.dm
@@ -226,7 +226,7 @@
 			if(BLUE_WARTEAM)
 				H.cmode_music = SSwarmongers.blu_warteam_cmode_music
 				if(warfare_faction == H.warfare_faction)
-					to_chat(H, "<span class='info'>Our COMMANDER has decided that we need a new song to guide our battles.</span>")
+					to_chat(H, "<span class='info'>Our LORD has decided that we need a new song to guide our battles.</span>")
 
 ///////////////////////////// RED ///////////////////////////////////////
 
@@ -701,7 +701,6 @@
 	backpack_contents = list(/obj/item/bomb/mollie=6)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/flintlocks, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
@@ -716,6 +715,7 @@
 		H.change_stat("endurance", 1)
 		H.change_stat("constitution", 1)
 		H.cmode_music = 'sound/music/soberandhatingit.ogg'
+		ADD_TRAIT(H, TRAIT_UNTRAINED, TRAIT_GENERIC)
 
 //// MEDIC ////
 
@@ -1034,7 +1034,7 @@
 	if(prob(50))
 		head = /obj/item/clothing/head/roguetown/war/stitchhood/alternate
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
@@ -1048,7 +1048,7 @@
 		H.change_stat("endurance", 4)
 		H.change_stat("constitution", 1)
 		H.cmode_music = 'sound/music/makeamartyrofme.ogg'
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_UNTRAINED, TRAIT_GENERIC)
 
 //// HUSSAR ////
 
@@ -1120,7 +1120,6 @@
 		H.change_stat("endurance", 1)
 		H.change_stat("constitution", 1)
 		H.cmode_music = 'sound/music/makeamartyrofme.ogg'
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 //// SNIPER ////
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/bulky.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/bulky.dm
@@ -11,7 +11,7 @@
 
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
-	inherent_traits = list(TRAIT_NOMOBSWAP, TRAIT_BIGHANDS)
+	inherent_traits = list(TRAIT_NOMOBSWAP)
 	default_features = list("mcolor" = "FFF", "wings" = "None")
 	use_skintones = 1
 	possible_ages = ALL_AGES_LIST


### PR DESCRIPTION
Bulky bodytypes can use guns, not being able to use guns is now solely class based not bodytype based. Firestarter and Zealot cannot use guns, Zealot updated to actually be proficient in the weapon they spawn with.
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
